### PR TITLE
Add StorageService interface and a HDFS connector as an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ Partial results for the second query on the `health` dataset is as follows
   ...
 ```
 
+### CONNECT TO EXTERNAL STORAGE SERVICES
+COOL has an [StorageService](cool-core/src/main/java/com/nus/cool/storageservice/StorageService.java) interface, which will allow COOL standalone server/workers (coming soon) to handle data movement between local and an external storage service. A sample implementation for HDFS connection can be found under the [hdfs-extensions](cool-extensions/hdfs-extensions/).
+
 ## Publication
 * Z. Xie, H. Ying, C. Yue, M. Zhang, G. Chen, B. C. Ooi. [Cool: a COhort OnLine analytical processing system](https://www.comp.nus.edu.sg/~ooibc/icde20cool.pdf) IEEE International Conference on Data Engineering, 2020
 * Q. Cai, Z. Xie, M. Zhang, G. Chen, H.V. Jagadish and B.C. Ooi. [Effective Temporal Dependence Discovery in Time Series Data](http://www.comp.nus.edu.sg/~ooibc/cohana18.pdf) ACM International Conference on Very Large Data Bases (VLDB), 2018

--- a/cool-core/pom.xml
+++ b/cool-core/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <groupId>org.nus</groupId>
+      <groupId>com.nus</groupId>
       <artifactId>cool</artifactId>
       <version>0.1-SNAPSHOT</version>
       <relativePath>..</relativePath>

--- a/cool-core/src/main/java/com/nus/cool/storageservice/StorageService.java
+++ b/cool-core/src/main/java/com/nus/cool/storageservice/StorageService.java
@@ -6,7 +6,8 @@ import java.nio.file.Path;
  * Storage Service defines external file storage services 
  *  that can be connected to COOL for loading and storing data.
  * 
- * This allows offloading the responsibility of availability, persistence, fault tolerance of data to the storage service.  
+ * This allows offloading the responsibility of availability,
+ *  persistence, fault tolerance of data to the storage service.  
  */
 public interface StorageService {
 

--- a/cool-core/src/main/java/com/nus/cool/storageservice/StorageService.java
+++ b/cool-core/src/main/java/com/nus/cool/storageservice/StorageService.java
@@ -1,0 +1,52 @@
+package com.nus.cool.storageservice;
+
+import java.nio.file.Path;
+
+/**
+ * Storage Service defines external file storage services 
+ *  that can be connected to COOL for loading and storing data.
+ * 
+ * This allows offloading the responsibility of availability, persistence, fault tolerance of data to the storage service.  
+ */
+public interface StorageService {
+
+  /**
+   * Load the data in storage service with the designated id to destDir.
+   * 
+   * @param id : name for the cube in storage service
+   * @param destDir : path to the cube to store
+   * @return
+   */
+  StorageServiceStatus loadData(String id, Path destDir);
+
+  /**
+   * Store the file(s) under destDir in storage service with the designated id
+   * 
+   * @param id : name for the cube in storage service
+   * @param destDir : path to the cube to store
+   * @return
+   */
+  StorageServiceStatus storeData(String id, Path srcDir);
+  
+  /**
+   * Compared to loadData, the destDir is expected to follow the
+   *  cube directory organization. This allows only more efficient
+   *  implementation. (for example only loading the new versions of a cube) 
+   * 
+   * @param cube : name for the cube in storage service
+   * @param destDir : path to the cube to store
+   * @return
+   */
+  StorageServiceStatus loadCube(String cube, Path destDir);
+  
+  /**
+   * Compared to storeData, the srcDir is expected to follow the
+   *  cube directory organization. This allows more efficient
+   *  implementation customized for COOL cube.
+   * 
+   * @param cube : name for the cube in storage service
+   * @param srcDir : path to the cube to store
+   * @return
+   */
+  StorageServiceStatus storeCube(String cube, Path srcDir);
+}

--- a/cool-core/src/main/java/com/nus/cool/storageservice/StorageServiceStatus.java
+++ b/cool-core/src/main/java/com/nus/cool/storageservice/StorageServiceStatus.java
@@ -1,0 +1,36 @@
+package com.nus.cool.storageservice;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class StorageServiceStatus {
+  public static enum StatusCode {
+    UNAVAILABLE,
+    OK,
+    ERROR
+  }
+
+  // status of the storage service
+  @Getter
+  final StatusCode code;
+  // auxiliary message from storage service
+  @Setter
+  @Getter
+  String msg;
+
+  public StorageServiceStatus(StatusCode code, String msg) {
+    this.code = code;
+    this.msg = msg;
+  }
+
+  public StorageServiceStatus(StatusCode code) {
+    this.code = code;
+    this.msg = "";
+  }
+
+  @Override
+  public String toString() {
+    return "Storage service status: " + code 
+      + (msg.isEmpty() ? "" : msg);  
+  }
+}

--- a/cool-core/src/main/java/com/nus/cool/storageservice/StorageServiceStatus.java
+++ b/cool-core/src/main/java/com/nus/cool/storageservice/StorageServiceStatus.java
@@ -3,31 +3,66 @@ package com.nus.cool.storageservice;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * Storage service status is returned after interaction with
+ *  storage service, indicating the operation status and retrieve
+ *  additional information passed by storage service
+ */
 public class StorageServiceStatus {
+  /**
+   * status code indicates the status of a storage service
+   *  after an operation. It is used to determine if we can continue
+   *  use the service.
+   */
   public static enum StatusCode {
+    /**
+     * Storage service is unavaible
+     */
     UNAVAILABLE,
+    /**
+     * Storage service is ok
+     */
     OK,
+    /**
+     * Errors occured in storage service
+     */
     ERROR
   }
 
   // status of the storage service
   @Getter
   final StatusCode code;
+
   // auxiliary message from storage service
   @Setter
   @Getter
   String msg;
 
+  /**
+   * Construct a storage service status with status code and message
+   * 
+   * @param code status code
+   * @param msg customized message
+   */
   public StorageServiceStatus(StatusCode code, String msg) {
     this.code = code;
     this.msg = msg;
   }
 
+  /**
+   * Construct a storge service status with status code and empty message
+   * 
+   * @param code status code
+   */
   public StorageServiceStatus(StatusCode code) {
     this.code = code;
     this.msg = "";
   }
 
+  /**
+   * output a string representation of the storage service status
+   *  including the status code and message assigned.
+   */
   @Override
   public String toString() {
     return "Storage service status: " + code 

--- a/cool-examples/load-csv/pom.xml
+++ b/cool-examples/load-csv/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <groupId>org.nus</groupId>
+      <groupId>com.nus</groupId>
       <artifactId>cool-examples</artifactId>
       <version>0.1-SNAPSHOT</version>
       <relativePath>..</relativePath>

--- a/cool-examples/load-parquet/pom.xml
+++ b/cool-examples/load-parquet/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <groupId>org.nus</groupId>
+      <groupId>com.nus</groupId>
       <artifactId>cool-examples</artifactId>
       <version>0.1-SNAPSHOT</version>
       <relativePath>..</relativePath>
@@ -14,7 +14,7 @@
 
     <dependencies>
         <dependency>
-          <groupId>org.nus</groupId>
+          <groupId>com.nus</groupId>
           <artifactId>parquet-extensions</artifactId>
           <version>${project.parent.version}</version>
         </dependency>

--- a/cool-examples/pom.xml
+++ b/cool-examples/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.nus</groupId>
+        <groupId>com.nus</groupId>
         <artifactId>cool</artifactId>
         <version>0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
@@ -21,7 +21,7 @@
 
     <dependencies>
         <dependency>
-          <groupId>org.nus</groupId>
+          <groupId>com.nus</groupId>
           <artifactId>cool-core</artifactId>
           <version>${project.parent.version}</version>
         </dependency>

--- a/cool-extensions/hdfs-extensions/pom.xml
+++ b/cool-extensions/hdfs-extensions/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.nus</groupId>
+        <artifactId>cool-extensions</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>hdfs-extensions</artifactId>
+    
+    <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+          <version>2.8.5</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-mapreduce-client-core</artifactId>
+          <version>2.8.5</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs</artifactId>
+          <version>2.8.5</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/cool-extensions/hdfs-extensions/src/main/java/com/nus/cool/extension/storageservice/HdfsStorageService.java
+++ b/cool-extensions/hdfs-extensions/src/main/java/com/nus/cool/extension/storageservice/HdfsStorageService.java
@@ -1,0 +1,84 @@
+package com.nus.cool.extension.storageservice;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+
+import com.nus.cool.storageservice.StorageService;
+import com.nus.cool.storageservice.StorageServiceStatus;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+public class HdfsStorageService implements StorageService {
+  
+  private final Path root;
+
+  private FileSystem fs; 
+
+  HdfsStorageService(String rootPath, Configuration conf)
+    throws IOException {
+    this.root = new Path(rootPath);
+    fs = FileSystem.get(conf);
+  }
+
+  HdfsStorageService(String hdfsHost, String rootPath, Configuration conf) 
+    throws URISyntaxException, IOException {
+    this.root = new Path(rootPath);
+    fs = FileSystem.get(new URI(hdfsHost), conf);
+  }
+
+  @Override
+  public StorageServiceStatus loadData(String id,
+    java.nio.file.Path destDir) {
+    try {
+      Path srcDir = root.suffix("/"+id);
+      if (!fs.exists(srcDir)) {
+        return new StorageServiceStatus(
+          StorageServiceStatus.StatusCode.ERROR,
+          "Data not found in HDFS at" + srcDir.toString());
+        }
+      Files.createDirectories(destDir);
+      fs.copyToLocalFile(srcDir, 
+        new Path(destDir.toFile().getAbsolutePath()));
+    } catch (IOException e) {
+      e.printStackTrace();
+      return new StorageServiceStatus(
+        StorageServiceStatus.StatusCode.ERROR, 
+        "Failed to load data from HDFS");
+    }
+    return new StorageServiceStatus(
+      StorageServiceStatus.StatusCode.OK, "");
+  }
+
+  @Override
+  public StorageServiceStatus storeData(String id,
+    java.nio.file.Path srcDir) {
+    try {
+      Path destDir = root.suffix("/"+id);
+    fs.copyFromLocalFile(new Path(srcDir.toFile().getAbsolutePath()),
+      destDir);
+    } catch (IOException e) {
+      e.printStackTrace();
+      return new StorageServiceStatus(
+        StorageServiceStatus.StatusCode.ERROR, 
+        "Failed to store data from HDFS");  
+    } 
+    return new StorageServiceStatus(
+      StorageServiceStatus.StatusCode.OK, "");    
+  }
+
+  @Override
+  public StorageServiceStatus loadCube(String cube,
+    java.nio.file.Path destDir) {
+    return loadData(cube, destDir);
+  }
+
+  @Override
+  public StorageServiceStatus storeCube(String cube,
+    java.nio.file.Path srcDir) {
+    return storeData(cube, srcDir);
+  }
+}

--- a/cool-extensions/hdfs-extensions/src/main/java/com/nus/cool/extension/storageservice/HdfsStorageService.java
+++ b/cool-extensions/hdfs-extensions/src/main/java/com/nus/cool/extension/storageservice/HdfsStorageService.java
@@ -12,17 +12,45 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+/**
+ * HDFS as storage services
+ *  manages transfer of data between local filesystem to a hdfs cluster
+ */
 public class HdfsStorageService implements StorageService {
   
+  /**
+   * the root path under which data is pushed to and pulled from
+   *  any hdfs path input will be prefixed with it.
+   */
   private final Path root;
 
+  /**
+   * HDFS instance
+   */
   private FileSystem fs; 
 
+  /**
+   * Constructor taking the root path in HDFS under which data tranfer happens, and HDFS configuration  
+   * 
+   * @param rootPath root path to pull and push data in HDFS
+   * @param conf HDFS configuration
+   * @throws IOException
+   */
   HdfsStorageService(String rootPath, Configuration conf)
-    throws IOException {
+  throws IOException {
     this.root = new Path(rootPath);
     fs = FileSystem.get(conf);
   }
+
+  /**
+   * Constructor taking the hdfs uri, root path in HDFS under which data tranfer happens, and HDFS configuration  
+   * 
+   * @param hdfsHost hdfs uri, example format: hdfs://<host>:<port>
+   * @param rootPath root path to pull and push data in HDFS
+   * @param conf HDFS configuration
+   * @throws URISyntaxException
+   * @throws IOException
+   */
 
   HdfsStorageService(String hdfsHost, String rootPath, Configuration conf) 
     throws URISyntaxException, IOException {
@@ -44,7 +72,6 @@ public class HdfsStorageService implements StorageService {
       fs.copyToLocalFile(srcDir, 
         new Path(destDir.toFile().getAbsolutePath()));
     } catch (IOException e) {
-      e.printStackTrace();
       return new StorageServiceStatus(
         StorageServiceStatus.StatusCode.ERROR, 
         "Failed to load data from HDFS");
@@ -61,7 +88,6 @@ public class HdfsStorageService implements StorageService {
     fs.copyFromLocalFile(new Path(srcDir.toFile().getAbsolutePath()),
       destDir);
     } catch (IOException e) {
-      e.printStackTrace();
       return new StorageServiceStatus(
         StorageServiceStatus.StatusCode.ERROR, 
         "Failed to store data from HDFS");  

--- a/cool-extensions/hdfs-extensions/src/test/java/com/nus/cool/extension/storageservice/HdfsStorageServiceIntegrationTest.java
+++ b/cool-extensions/hdfs-extensions/src/test/java/com/nus/cool/extension/storageservice/HdfsStorageServiceIntegrationTest.java
@@ -1,0 +1,64 @@
+package com.nus.cool.extension.storageservice;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+import com.nus.cool.storageservice.StorageService;
+import com.nus.cool.storageservice.StorageServiceStatus;
+
+import org.apache.hadoop.conf.Configuration;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class HdfsStorageServiceIntegrationTest {
+  
+  @Test
+  public void testSaveLoad() {
+    
+    java.nio.file.Path dummyDir = java.nio.file.Paths.get("dummy");
+    java.nio.file.Path reloadDir = java.nio.file.Paths.get("loaddummy");
+    File dummyFile = new File("dummy/dummy2.txt");
+
+    try {
+      Files.createDirectories(dummyDir);
+      dummyFile.createNewFile();
+    } catch (IOException e) {
+      Assert.fail("Unable to create dummy files for testing");
+    }
+
+    try {
+      // replace the host and port with valid input of your hdfs.
+      StorageService storageService = new HdfsStorageService("hdfs://<host>:<port>", "/user/hdfs/", new Configuration());
+      
+      StorageServiceStatus status = storageService.storeData("dummydata", dummyDir); 
+      if(status.getCode() != StorageServiceStatus.StatusCode.OK) {
+        Assert.fail(status.getMsg());
+      };
+      status = storageService.loadData("dummydata", reloadDir);
+      if(status.getCode() != StorageServiceStatus.StatusCode.OK) {
+        Assert.fail(status.getMsg());
+      }
+    } catch (IOException | URISyntaxException e) {
+      e.printStackTrace();
+      Assert.fail("Failed to connect to to hdfs service" + 
+        "at local host port 20131\n");
+    }
+    try {
+      dummyFile.delete();
+      Files.delete(dummyDir);
+      Files.walk(reloadDir)
+           .sorted(Comparator.reverseOrder())
+           .map(Path::toFile)
+           .forEach(File::delete);
+      Assert.assertFalse(Files.exists(reloadDir));
+      Assert.assertFalse(Files.exists(dummyDir));
+    } catch (IOException e) {
+      Assert.fail("Failed to garbage clean dummy files for testing" +
+        "please remove them manually\n");
+    }
+  }
+}

--- a/cool-extensions/hdfs-extensions/src/test/java/com/nus/cool/extension/storageservice/HdfsStorageServiceIntegrationTest.java
+++ b/cool-extensions/hdfs-extensions/src/test/java/com/nus/cool/extension/storageservice/HdfsStorageServiceIntegrationTest.java
@@ -43,7 +43,6 @@ public class HdfsStorageServiceIntegrationTest {
         Assert.fail(status.getMsg());
       }
     } catch (IOException | URISyntaxException e) {
-      e.printStackTrace();
       Assert.fail("Failed to connect to to hdfs service" + 
         "at local host port 20131\n");
     }

--- a/cool-extensions/parquet-extensions/pom.xml
+++ b/cool-extensions/parquet-extensions/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <groupId>org.nus</groupId>
+      <groupId>com.nus</groupId>
       <artifactId>cool-extensions</artifactId>
       <version>0.1-SNAPSHOT</version>
       <relativePath>..</relativePath>

--- a/cool-extensions/pom.xml
+++ b/cool-extensions/pom.xml
@@ -16,6 +16,7 @@
 
     <modules>
         <module>parquet-extensions</module>
+        <module>hdfs-extensions</module>
     </modules>
 
     <dependencies>

--- a/cool-extensions/pom.xml
+++ b/cool-extensions/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.nus</groupId>
+        <groupId>com.nus</groupId>
         <artifactId>cool</artifactId>
         <version>0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
@@ -20,7 +20,7 @@
 
     <dependencies>
         <dependency>
-          <groupId>org.nus</groupId>
+          <groupId>com.nus</groupId>
           <artifactId>cool-core</artifactId>
           <version>${project.parent.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,18 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            **/*IntegrationTest.java
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.2</version>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.nus</groupId>
+    <groupId>com.nus</groupId>
     <artifactId>cool</artifactId>
     <version>0.1-SNAPSHOT</version>
     <packaging>pom</packaging>


### PR DESCRIPTION
This PR adds a storage service interface to COOL and the extension module hdfs-extensions as a sample implementation of it.

Adding the storage service implementation allows cool to offload the responsibility to keep data available and fault-tolerant to external storage services. This also facilitates the storage-compute separation and allows launching COOL workers on top of a shared storage layer in the future, which can be on cloud. More connectors to cloud services like AWS S3, and GCP Cloud Storage shall be supported later.