### PR TITLE
Minor fix loader

### DIFF
--- a/cool-core/src/main/java/com/nus/cool/loader/DataLoader.java
+++ b/cool-core/src/main/java/com/nus/cool/loader/DataLoader.java
@@ -157,8 +157,7 @@ public class DataLoader {
         int tuples = 0;
         ChunkWS chunk = ChunkWS.newChunk(tableSchema, metaFields, offset);
         while (reader.hasNext()) {
-            String line = (String) reader.next();
-            String[] tuple = parser.parse(line);
+            String[] tuple = parser.parse(reader.next());
             String curUser = tuple[userKeyIndex];
             if (lastUser == null) {
                 lastUser = curUser;

--- a/cool-examples/load-csv/src/main/java/com/nus/cool/example/Main.java
+++ b/cool-examples/load-csv/src/main/java/com/nus/cool/example/Main.java
@@ -39,7 +39,6 @@ public class Main {
    * @param args there are five arguments. List in input order
    *  (1) output cube name: to be specified when loading from the repository
    *  (2) table.yaml (3) dimension.csv (4) data.csv (5) output cube repository 
-   *  (6) chunkSize(Int) number of tuples in a chunk
    * @throws IOException
    */
   public static void main(String[] args) {

--- a/cool-examples/load-parquet/src/main/java/com/nus/cool/example/Main.java
+++ b/cool-examples/load-parquet/src/main/java/com/nus/cool/example/Main.java
@@ -40,7 +40,6 @@ public class Main {
    * @param args there are five arguments. List in input order
    *  (1) output cube name: to be specified when loading from the repository
    *  (2) table.yaml (3) dimension.csv (4) data.csv (5) output cube repository 
-   *  (6) chunkSize(Int) number of tuples in a chunk
    * @throws IOException
    */
   public static void main(String[] args) {
@@ -48,10 +47,8 @@ public class Main {
     String schemaFileName = args[1];
     File schemaFile = new File(schemaFileName);
     File dimensionFile = new File(args[2]);
-    // we create a sample parquet with the first three record from sogamo
     try {
       File dataFile = new File(args[3]);
-      // File dataFile = new File("tmp/parquet-sample-data/test.parquet");
       String cubeRepo = args[4];
       TableSchema schema = TableSchema.read(
         new FileInputStream(schemaFile));

--- a/cool-extensions/parquet-extensions/src/main/java/com/nus/cool/extension/util/reader/ParquetTupleReader.java
+++ b/cool-extensions/parquet-extensions/src/main/java/com/nus/cool/extension/util/reader/ParquetTupleReader.java
@@ -65,7 +65,7 @@ public class ParquetTupleReader implements TupleReader {
    * @return the original line
    */
   @Override
-  public Object next() throws IOException{
+  public Object next() throws IOException {
     String old = this.record.orElse("");
     this.record = converter.convert(Optional.ofNullable(this.reader.read()));
     return old;


### PR DESCRIPTION
This PR has two minor fixes related to data loader codes
1. remove outdated comments in data loading example codes
2. remove the conversion of TupleReader to string before passing to tuple parser. Relaxing such constrains makes data loader config to define customized tuple reader and parser use types known to them.