### PR TITLE
Add new api to upload csv, table.yaml, and query into HDFS

### DIFF
--- a/cool-core/src/main/java/com/nus/cool/core/util/writer/CliDataWriter.java
+++ b/cool-core/src/main/java/com/nus/cool/core/util/writer/CliDataWriter.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 public class CliDataWriter implements DataWriter {
   
   @Override
-  public boolean Initialize() throws IOException {
+  public boolean Initialize(String... fileName) throws IOException {
     System.out.println("------Display data set------");
     return true;
   }

--- a/cool-core/src/main/java/com/nus/cool/core/util/writer/DataWriter.java
+++ b/cool-core/src/main/java/com/nus/cool/core/util/writer/DataWriter.java
@@ -7,11 +7,11 @@ public interface DataWriter extends Closeable {
   
   /**
    * Initialize the writer
-   * 
+   * @Params fileName: file name of dz
    * @return successful initialization
    * @throws IOException
    */
-  boolean Initialize() throws IOException;
+  boolean Initialize(String... fileName) throws IOException;
 
   /**
    * Add a tuple to the data set

--- a/cool-core/src/main/java/com/nus/cool/core/util/writer/ListDataWriter.java
+++ b/cool-core/src/main/java/com/nus/cool/core/util/writer/ListDataWriter.java
@@ -40,7 +40,7 @@ public class ListDataWriter implements DataWriter {
   }
   
   @Override
-  public boolean Initialize() throws IOException {
+  public boolean Initialize(String... fileName) throws IOException {
     return true;
   }
 

--- a/cool-core/src/main/java/com/nus/cool/core/util/writer/NativeDataWriter.java
+++ b/cool-core/src/main/java/com/nus/cool/core/util/writer/NativeDataWriter.java
@@ -66,7 +66,7 @@ public class NativeDataWriter implements DataWriter {
     private DataOutputStream out = null;
 
     @Override
-    public boolean Initialize() throws IOException {
+    public boolean Initialize(String... fileName) throws IOException {
         if (initalized) return true;
         this.userKeyIndex = tableSchema.getUserKeyField();
         // when there is no user key, using any field for the additional condition on chunk switch is ok.
@@ -74,7 +74,7 @@ public class NativeDataWriter implements DataWriter {
         // cublet
         // create metaChunk instance, default offset to be 0, update offset when write later.
         this.metaChunk = MetaChunkWS.newMetaChunkWS(this.tableSchema, 0);
-        this.out = newCublet();
+        this.out = newCublet(fileName);
         // chunk
         this.tupleCount = 0;
         this.offset = 0;
@@ -137,8 +137,15 @@ public class NativeDataWriter implements DataWriter {
      * @return DataOutputStream
      * @throws IOException
      */
-    private DataOutputStream newCublet() throws IOException {
-        String fileName = Long.toHexString(System.currentTimeMillis()) + ".dz";
+    private DataOutputStream newCublet(String... fileNameParams) throws IOException {
+
+        // if file name is provided, then use it.
+        String fileName;
+        if (fileNameParams.length == 1){
+            fileName = fileNameParams[0];
+        }else{
+            fileName = Long.toHexString(System.currentTimeMillis()) + ".dz";
+        }
         System.out.println("[*] A new cublet "+ fileName + " is created!");
         File cublet = new File(outputDir, fileName);
         DataOutputStream out = new DataOutputStream(new FileOutputStream(cublet));

--- a/cool-core/src/main/java/com/nus/cool/loader/DataLoader.java
+++ b/cool-core/src/main/java/com/nus/cool/loader/DataLoader.java
@@ -70,9 +70,9 @@ public class DataLoader {
     /**
      * load data into cool native format
      */
-    public void load() throws IOException {
+    public void load(String... fileName) throws IOException {
         // write dataChunk first
-        writer.Initialize();
+        writer.Initialize(fileName);
         // read the data
         while (reader.hasNext()) {
             writer.Add(parser.parse(reader.next()));

--- a/cool-core/src/main/java/com/nus/cool/loader/LoadQuery.java
+++ b/cool-core/src/main/java/com/nus/cool/loader/LoadQuery.java
@@ -33,6 +33,10 @@ public class LoadQuery {
     private String outputPath;
     private String configPath;
 
+    // after writing dz, table file, records the path inside the server.
+    private String dzFilePath;
+    private String TableFilePath;
+
     public boolean isValid() throws IOException {
         boolean f = true;
         if (dataFileType == "AVRO") f = isExist(configPath);

--- a/cool-core/src/main/java/com/nus/cool/model/CoolLoader.java
+++ b/cool-core/src/main/java/com/nus/cool/model/CoolLoader.java
@@ -93,8 +93,8 @@ public class CoolLoader {
         String dzPath;
         String tablePath;
         if (fileName.length == 1){
-            dzPath = cubeRepo+"/"+ dataSourceName+"/"+outputCubeVersionDir.getName()+"/"+fileName[0];
-            tablePath = cubeRepo+"/"+ dataSourceName+"/"+outputCubeVersionDir.getName()+"/table.yaml";
+            dzPath = dataSourceName+"/"+outputCubeVersionDir.getName()+"/"+fileName[0];
+            tablePath = dataSourceName+"/"+outputCubeVersionDir.getName()+"/table.yaml";
             return new String[]{dzPath, tablePath};
         }else{
             return new String[]{};

--- a/cool-core/src/main/java/com/nus/cool/model/CoolLoader.java
+++ b/cool-core/src/main/java/com/nus/cool/model/CoolLoader.java
@@ -40,12 +40,13 @@ public class CoolLoader {
 
     /**
      *
-     * @param dataSourceName output cube name. Need to be specified when loading from the repository
-     * @param schemaFileName path to the table.yaml
-     * @param dataFileName path to the data.csv
-     * @param cubeRepo the name of the output cube repository
+     * @param dataSourceName output cube name. Need to be specified when loading from the repository, eg, sogamo
+     * @param schemaFileName path to the table.yaml, eg. sogamo/table.yaml
+     * @param dataFileName path to the data.csv, eg. sogamo/test.csv
+     * @param cubeRepo the name of the output cube repository. eg. datasetSource
+     * @return dz file path, table.yaml path.
      */
-    public synchronized void load(String dataSourceName, String schemaFileName, String dataFileName, String cubeRepo) throws IOException{
+    public synchronized String[] load(String dataSourceName, String schemaFileName, String dataFileName, String cubeRepo, String... fileName) throws IOException{
 
         // check the existence of the data repository
         File root = new File(cubeRepo);
@@ -85,9 +86,19 @@ public class CoolLoader {
             System.out.println("[*] New version " + outputCubeVersionDir.getName() + " is created!");
         }
         DataLoader loader = DataLoader.builder(dataSourceName, schema, dataFile, outputCubeVersionDir, this.loaderConfig).build();
-        loader.load();
+        loader.load(fileName);
         // copy the table.yaml to new version folder
         Files.copy(schemaFile, new File(outputCubeVersionDir, "table.yaml"));
+
+        String dzPath;
+        String tablePath;
+        if (fileName.length == 1){
+            dzPath = cubeRepo+"/"+ dataSourceName+"/"+outputCubeVersionDir.getName()+"/"+fileName[0];
+            tablePath = cubeRepo+"/"+ dataSourceName+"/"+outputCubeVersionDir.getName()+"/table.yaml";
+            return new String[]{dzPath, tablePath};
+        }else{
+            return new String[]{};
+        }
     }
 
 

--- a/cool-core/src/test/java/com/nus/cool/core/model/CoolModelTest.java
+++ b/cool-core/src/test/java/com/nus/cool/core/model/CoolModelTest.java
@@ -35,6 +35,11 @@ public class CoolModelTest {
 
         DataLoaderConfig config = new CsvDataLoaderConfig();
         CoolLoader loader = new CoolLoader(config);
+
+        // load with dz name
+        String fileName = Long.toHexString(System.currentTimeMillis()) + ".dz";
+        loader.load(cube, schemaFileName, dataFileName, cubeRepo, fileName);
+        // load without dz name
         loader.load(cube, schemaFileName, dataFileName, cubeRepo);
 
         cube = "tpc-h-10g";

--- a/cool-queryserver/src/main/java/com/nus/cool/queryserver/handler/BrokerController.java
+++ b/cool-queryserver/src/main/java/com/nus/cool/queryserver/handler/BrokerController.java
@@ -63,6 +63,40 @@ public class BrokerController {
         return  null;
     }
 
+    /**
+     * Receive query file from client, and store to local as temp_query.json, and then upload to hdfs.
+     * @param queryFile query file
+     * @return response
+     * @throws URISyntaxException exception
+     * @throws IOException exception
+     */
+    @PostMapping(value = "/load-query-to-hdfs",
+            produces = MediaType.APPLICATION_JSON_VALUE,
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<String> loadQueryToDfs(@RequestParam("queryFile") MultipartFile queryFile) throws URISyntaxException, IOException {
+
+        // 1. connect to hdfs, get data Source Name, cohort or iceberg
+        HDFSConnection fs = HDFSConnection.getInstance();
+
+        Util.getTimeClock();
+        System.out.println("[*] This query is for iceberg query: " + queryFile);
+        String queryContent = new String(queryFile.getBytes());
+        ObjectMapper mapper = new ObjectMapper();
+        IcebergQuery q = mapper.readValue(queryContent, IcebergQuery.class);
+
+        try {
+            // Writing to a file
+            mapper.writeValue(new File("temp_query.json"), q );
+            String localPath3 = "temp_query.json";
+            String dfsPath3 = "/tmp/1/query.json";
+            fs.uploadToDfs(localPath3, dfsPath3);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return  null;
+    }
+
     @GetMapping(value = "/execute")
     public ResponseEntity<String> handler(@RequestParam Map<String, String> params){
         System.out.println(params);

--- a/cool-queryserver/src/main/java/com/nus/cool/queryserver/model/QueryServerModel.java
+++ b/cool-queryserver/src/main/java/com/nus/cool/queryserver/model/QueryServerModel.java
@@ -52,9 +52,10 @@ public class QueryServerModel {
     /**
      * Load a new cube
      * @param q query instance
+     * @param fileName optional, dz name.
      * @return Response
      */
-    public static ResponseEntity<String> loadCube(LoadQuery q) {
+    public static ResponseEntity<String> loadCube(LoadQuery q, String... fileName) {
         try {
             q.isValid();
             String fileType = q.getDataFileType().toUpperCase();
@@ -77,7 +78,13 @@ public class QueryServerModel {
             }
             System.out.println(config.getClass().getName());
             CoolLoader coolLoader = new CoolLoader(config);
-            coolLoader.load(q.getCubeName(),q.getSchemaPath(), q.getDataPath(),q.getOutputPath());
+            String[] dzTableNames = coolLoader.load(q.getCubeName(),q.getSchemaPath(), q.getDataPath(),q.getOutputPath(), fileName);
+
+            if (dzTableNames.length == 2){
+                q.setDzFilePath(dzTableNames[0]);
+                q.setTableFilePath(dzTableNames[1]);
+            }
+
             String resStr = "Cube " + q.getCubeName() + " has already been loaded.";
             return ResponseEntity.ok().headers(HttpHeaders.EMPTY).body(resStr);
         } catch (Exception e){


### PR DESCRIPTION
1. Enable provide .dz file name in the loading process. 
2. Add distributed APIs to enable users to load local CSV and upload it to HDFS. 
3. Add distributed APIs to enable users to upload queries.json files, store them locally, and upload them into HDFS.
4. Add comments. 