### PR TITLE
Add cube meta

### DIFF
--- a/cool-core/src/main/java/com/nus/cool/core/io/readstore/CubeMetaRS.java
+++ b/cool-core/src/main/java/com/nus/cool/core/io/readstore/CubeMetaRS.java
@@ -1,0 +1,188 @@
+package com.nus.cool.core.io.readstore;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
+import com.google.common.primitives.Ints;
+import com.nus.cool.core.io.Input;
+import com.nus.cool.core.io.storevector.InputVector;
+import com.nus.cool.core.io.storevector.InputVectorFactory;
+import com.nus.cool.core.io.storevector.LZ4InputVector;
+import com.nus.cool.core.schema.ChunkType;
+import com.nus.cool.core.schema.FieldType;
+import com.nus.cool.core.schema.TableSchema;
+
+import lombok.Data;
+
+public class CubeMetaRS implements Input {
+
+  /**
+   * TableSchema for this meta chunk
+   */
+  private TableSchema schema;
+
+  /**
+   * charset defined in table schema
+   */
+  private Charset charset;
+
+  /**
+   * stored data byte buffer
+   */
+  private ByteBuffer buffer;
+
+  /**
+   * offsets for fields in this meta chunk
+   */
+  private int[] fieldOffsets;
+
+  
+  private interface FieldMeta extends Input {
+    String generateJson();
+  } 
+  
+  @Data
+  private class RangeFieldMeta implements FieldMeta {
+    private FieldType type;
+
+    private int min;
+
+    private int max;
+    
+    public RangeFieldMeta(FieldType type) {
+      this.type = type;
+    }
+    @Override
+    public void readFrom(ByteBuffer buf) {
+      this.min = buffer.getInt();
+      this.max = buffer.getInt();
+    }
+    
+    @Override
+    public String generateJson() {
+      ObjectMapper mapper = new ObjectMapper();
+      try {
+        return mapper.writeValueAsString(this);
+      } catch (JsonProcessingException e) {
+        System.err.println(e);
+        return "{\"error\": \"failed to generate json\"}";
+      }
+    }
+  }
+  
+  @Data
+  private class HashFieldMeta implements FieldMeta {
+
+    private Charset charset;
+
+    private FieldType type;
+    
+    private List<String> values;
+
+    public HashFieldMeta(FieldType type, Charset charset) {
+      this.type = type;
+      this.charset = charset;
+    }
+
+    @Override
+    public void readFrom(ByteBuffer buffer) {
+      InputVector vec = InputVectorFactory.readFrom(buffer);
+      if (!(vec instanceof LZ4InputVector)) {
+        return;
+      } 
+
+      LZ4InputVector value_vec = (LZ4InputVector) vec;
+      int value_count = value_vec.size();
+      values = new ArrayList<>(value_count);
+      for (int i = 0; i < value_count; i++) {
+        String value = value_vec.getString(i, this.charset);
+        values.add(value);
+      } 
+    }
+      
+    @Override
+    public String generateJson() {
+      ObjectMapper mapper = new ObjectMapper();
+      try {
+        return mapper.writeValueAsString(this);
+      } catch (JsonProcessingException e) {
+        System.err.println(e);
+        return "{\"error\": \"failed to generate json\"}";
+      }
+    }
+  }
+
+  private Map<Integer, FieldMeta> fields = Maps.newHashMap();
+  
+  public CubeMetaRS(TableSchema schema) {
+    this.schema = checkNotNull(schema);
+    this.charset = Charset.forName(this.schema.getCharset());
+  }
+
+  @Override
+  public void readFrom(ByteBuffer buffer) {
+    // Read header
+    // Get chunk type
+    this.buffer = checkNotNull(buffer);
+    buffer.position(buffer.limit() - Ints.BYTES);
+    int headOffset = this.buffer.getInt();
+    buffer.position(headOffset);
+    ChunkType chunkType = ChunkType.fromInteger(this.buffer.get());
+      if (chunkType != ChunkType.META) {
+          throw new IllegalStateException("Expect MetaChunk, but reads: " + chunkType);
+      }
+
+    // Get #fields
+    int num_fields = this.buffer.getInt();
+    // Get field offsets
+    this.fieldOffsets = new int[num_fields];
+    for (int i = 0; i < num_fields; i++) {
+        fieldOffsets[i] = this.buffer.getInt();
+    }
+    // Fields are loaded only if they are called
+  }
+
+  public synchronized String getFieldMeta(String fieldName) {
+    int id = this.schema.getFieldID(fieldName);
+    FieldType type = this.schema.getFieldType(fieldName);
+    if (id < 0 || id >= this.fieldOffsets.length) return "";
+    
+    if (this.fields.containsKey(id)) {
+      return this.fields.get(id).generateJson();
+    }
+
+    int fieldOffset = this.fieldOffsets[id];
+    this.buffer.position(fieldOffset);
+    FieldMeta field = null;
+    switch (type) {
+      case UserKey:
+      case Action:
+      case Segment:
+        field = new HashFieldMeta(type, this.charset);
+        break;
+      case Metric:
+      case ActionTime:
+        field = new RangeFieldMeta(type);
+        break;
+      default:
+        throw new IllegalArgumentException("Unexpected FieldType: " + type);
+    }
+
+    this.fields.put(id, field);
+    field.readFrom(buffer);
+    return field.generateJson();
+  }
+
+  @Override
+  public String toString() {
+    return "cube meta file";
+  }
+}

--- a/cool-core/src/main/java/com/nus/cool/core/io/readstore/CubletRS.java
+++ b/cool-core/src/main/java/com/nus/cool/core/io/readstore/CubletRS.java
@@ -109,9 +109,9 @@ public class CubletRS implements Input {
     buffer.position(headOffset);
     int chunks = buffer.getInt();
     int[] chunkOffsets = new int[chunks];
-      for (int i = 0; i < chunks; i++) {
-          chunkOffsets[i] = buffer.getInt();
-      }
+    for (int i = 0; i < chunks; i++) {
+      chunkOffsets[i] = buffer.getInt();
+    }
 
     // read the metaChunk, which is the last one in #chunks
     this.metaChunk = new MetaChunkRS(this.schema);

--- a/cool-core/src/main/java/com/nus/cool/core/io/writestore/MetaChunkWS.java
+++ b/cool-core/src/main/java/com/nus/cool/core/io/writestore/MetaChunkWS.java
@@ -162,53 +162,47 @@ public class MetaChunkWS implements Output {
     public int writeTo(DataOutput out) throws IOException {
         int bytesWritten = 0;
 
-        // Store field offsets and write MetaFields as MetaChunkData layout
-        int[] offsets = new int[this.metaFields.length];
-        for (int i = 0; i < this.metaFields.length; i++) {
-            offsets[i] = this.offset + bytesWritten;
-            if(i==userKeyIndex){
-                bytesWritten += this.metaFields[i].writeTo(out);
-            }
-            else{
-                bytesWritten += this.metaFields[i].writeTo(out);
-            }
-        }
-
-        // Store header offset for MetaChunk layout
-        int headOffset = this.offset + bytesWritten;
-
-        // 1. Write ChunkType for header layout
-        out.writeByte(ChunkType.META.ordinal());
-        bytesWritten++;
-
-        // 2.1 Write fields for header layout
-        out.writeInt(IntegerUtil.toNativeByteOrder(this.metaFields.length));
-        bytesWritten += Ints.BYTES;
-
-        // 2.2 Write field offsets for header layout
-        for (int offset : offsets) {
-            out.writeInt(IntegerUtil.toNativeByteOrder(offset));
-            bytesWritten += Ints.BYTES;
-        }
-
-        // 3. Write header offset for MetaChunk layout
-        out.writeInt(IntegerUtil.toNativeByteOrder(headOffset));
-        bytesWritten += Ints.BYTES;
-        return bytesWritten;
+    // Store field offsets and write MetaFields as MetaChunkData layout
+    int[] offsets = new int[this.metaFields.length];
+    for (int i = 0; i < this.metaFields.length; i++) {
+      offsets[i] = this.offset + bytesWritten;
+      bytesWritten += this.metaFields[i].writeTo(out);
     }
 
-    @Override
-    public String toString() {
-        return "MetaChunk: " + Arrays.asList(metaFields).stream()
-                .map(Object::toString).reduce((x, y) -> x + ", " + y);
+    // Store header offset for MetaChunk layout
+    int headOffset = this.offset + bytesWritten;
+
+    // 1. Write ChunkType for header layout
+    out.writeByte(ChunkType.META.ordinal());
+    bytesWritten++;
+
+    // 2.1 Write fields for header layout
+    out.writeInt(IntegerUtil.toNativeByteOrder(this.metaFields.length));
+    bytesWritten += Ints.BYTES;
+
+    // 2.2 Write field offsets for header layout
+    for (int offset : offsets) {
+      out.writeInt(IntegerUtil.toNativeByteOrder(offset));
+      bytesWritten += Ints.BYTES;
     }
 
-    /**
-     * Update beginning offset to write the
-     *
-     * @param newOffset: new offset to write metaChunk
-     */
-    public void updateBeginOffset(int newOffset) {
-        this.offset = newOffset;
-    }
+    // 3. Write header offset for MetaChunk layout
+    out.writeInt(IntegerUtil.toNativeByteOrder(headOffset));
+    bytesWritten += Ints.BYTES;
+    return bytesWritten;
+  }
+
+  @Override
+  public String toString() {
+    return "MetaChunk: " + Arrays.asList(metaFields).stream()
+      .map(Object::toString).reduce((x, y) -> x + ", " + y);
+  }
+
+  /**
+   * Update beginning offset to write the
+   * @param newOffset: new offset to write metaChunk
+   */
+  public void updateBeginOffset(int newOffset){
+    this.offset = newOffset;
+  }
 }

--- a/cool-core/src/main/java/com/nus/cool/core/io/writestore/MetaChunkWS.java
+++ b/cool-core/src/main/java/com/nus/cool/core/io/writestore/MetaChunkWS.java
@@ -134,7 +134,9 @@ public class MetaChunkWS implements Output {
             if (userKeyIndex == i) {
                 List<String> userData = new ArrayList<>();
                 userData.add(tuple[userKeyIndex]);
-                for (int j = 0; j < invariantFieldIndex.size(); j++) userData.add(tuple[invariantFieldIndex.get(i)]);
+                for (int j = 0; j < invariantFieldIndex.size(); j++) {
+                  userData.add(tuple[invariantFieldIndex.get(i)]);
+                } 
                 ((MetaUserFieldWS) this.metaFields[i]).put((String[])userData.toArray(new String[0]),invariantType);
             } else {
                 this.metaFields[i].put(tuple[i]);
@@ -206,7 +208,7 @@ public class MetaChunkWS implements Output {
     int[] offsets = new int[this.metaFields.length];
     for (int i = 0; i < this.metaFields.length; i++) {
       offsets[i] = this.offset + bytesWritten;
-      bytesWritten += this.metaFields[i].writeTo(out);
+      bytesWritten += this.metaFields[i].writeCubeMeta(out);
     }
 
     // Store header offset for MetaChunk layout

--- a/cool-core/src/main/java/com/nus/cool/core/io/writestore/MetaChunkWS.java
+++ b/cool-core/src/main/java/com/nus/cool/core/io/writestore/MetaChunkWS.java
@@ -160,7 +160,6 @@ public class MetaChunkWS implements Output {
    */
   @Override
   public int writeTo(DataOutput out) throws IOException {
-    this.offset = 0;
     int bytesWritten = 0;
 
     // Store field offsets and write MetaFields as MetaChunkData layout
@@ -200,6 +199,7 @@ public class MetaChunkWS implements Output {
   }
 
   public int writeCubeMeta(DataOutput out) throws IOException {
+    this.offset = 0;
     int bytesWritten = 0;
 
     // Store field offsets and write MetaFields as MetaChunkData layout

--- a/cool-core/src/main/java/com/nus/cool/core/io/writestore/MetaChunkWS.java
+++ b/cool-core/src/main/java/com/nus/cool/core/io/writestore/MetaChunkWS.java
@@ -151,16 +151,56 @@ public class MetaChunkWS implements Output {
         }
     }
 
-    /**
-     * Write MetaChunkWS to out stream and return bytes written
-     *
-     * @param out stream can write data to output stream
-     * @return How many bytes has been written
-     * @throws IOException If an I/O error occurs
-     */
-    @Override
-    public int writeTo(DataOutput out) throws IOException {
-        int bytesWritten = 0;
+  /**
+   * Write MetaChunkWS to out stream and return bytes written
+   *
+   * @param out stream can write data to output stream
+   * @return How many bytes has been written
+   * @throws IOException If an I/O error occurs
+   */
+  @Override
+  public int writeTo(DataOutput out) throws IOException {
+    this.offset = 0;
+    int bytesWritten = 0;
+
+    // Store field offsets and write MetaFields as MetaChunkData layout
+    int[] offsets = new int[this.metaFields.length];
+    for (int i = 0; i < this.metaFields.length; i++) {
+      offsets[i] = this.offset + bytesWritten;
+      bytesWritten += this.metaFields[i].writeTo(out);
+    }
+
+    // Store header offset for MetaChunk layout
+    int headOffset = this.offset + bytesWritten;
+
+    // 1. Write ChunkType for header layout
+    out.writeByte(ChunkType.META.ordinal());
+    bytesWritten++;
+
+    // 2.1 Write fields for header layout
+    out.writeInt(IntegerUtil.toNativeByteOrder(this.metaFields.length));
+    bytesWritten += Ints.BYTES;
+
+    // 2.2 Write field offsets for header layout
+    for (int offset : offsets) {
+      out.writeInt(IntegerUtil.toNativeByteOrder(offset));
+      bytesWritten += Ints.BYTES;
+    }
+
+    // 3. Write header offset for MetaChunk layout
+    out.writeInt(IntegerUtil.toNativeByteOrder(headOffset));
+    bytesWritten += Ints.BYTES;
+    return bytesWritten;
+  }
+
+  public void cleanForNextCublet() {
+    for (MetaFieldWS metaField : this.metaFields) {
+      metaField.cleanForNextCublet();
+    }
+  }
+
+  public int writeCubeMeta(DataOutput out) throws IOException {
+    int bytesWritten = 0;
 
     // Store field offsets and write MetaFields as MetaChunkData layout
     int[] offsets = new int[this.metaFields.length];

--- a/cool-core/src/main/java/com/nus/cool/core/io/writestore/MetaFieldWS.java
+++ b/cool-core/src/main/java/com/nus/cool/core/io/writestore/MetaFieldWS.java
@@ -18,6 +18,9 @@
  */
 package com.nus.cool.core.io.writestore;
 
+import java.io.DataOutput;
+import java.io.IOException;
+
 import com.nus.cool.core.io.Output;
 import com.nus.cool.core.schema.FieldType;
 
@@ -30,11 +33,6 @@ public interface MetaFieldWS extends Output {
    */
   void put(String v);
 
-  /**
-   * Update the meta with value
-   * @param v value
-   */
-  void update(String v);
 
   /**
    * Find the index of value in this meta field, return -1 if no such value exists
@@ -63,4 +61,19 @@ public interface MetaFieldWS extends Output {
    * method returns, this meta field is frozen for writing.
    */
   void complete();
+
+  /**
+   * clean internal data for processing next cublet
+   */
+  void cleanForNextCublet();
+
+
+  /**
+   * write the summary of this field to cube meta file
+   * @param out: the cube meta file
+   * @return bytes written
+   * @throws IOException
+   */
+  public int writeCubeMeta(DataOutput out) throws IOException;
+  
 }

--- a/cool-core/src/main/java/com/nus/cool/core/io/writestore/MetaUserFieldWS.java
+++ b/cool-core/src/main/java/com/nus/cool/core/io/writestore/MetaUserFieldWS.java
@@ -65,7 +65,6 @@ public class MetaUserFieldWS extends MetaHashFieldWS {
         int hashKey = rhash.hash(tupleValue[0]);
         if (!this.hashToTerm.containsKey(hashKey)) {
             this.hashToTerm.put(hashKey, new Term(tupleValue[0], nextGid++));
-            this.gidToHash.add(hashKey);
         }
         if (tupleValue.length == 1) return;
         else {

--- a/cool-core/src/main/java/com/nus/cool/core/util/writer/NativeDataWriter.java
+++ b/cool-core/src/main/java/com/nus/cool/core/util/writer/NativeDataWriter.java
@@ -188,12 +188,25 @@ public class NativeDataWriter implements DataWriter {
         return true;
     }
 
+    private void GenerateCubeMeta() throws IOException {
+      if (!finished) return;
+      String fileName = "cubemeta";
+      File cubemeta = new File(outputDir, fileName);
+      DataOutputStream out = new DataOutputStream(
+        new FileOutputStream(cubemeta));
+      offset = 0;
+      metaChunk.writeCubeMeta(out);
+      out.flush();
+      out.close();
+    }
+
     @Override
     public void Finish() throws IOException {
         if (finished) return;
         finishChunk();
         finishCublet();
         finished = true;
+        GenerateCubeMeta();
     }
 
     @Override

--- a/cool-core/src/main/java/com/nus/cool/core/util/writer/NativeDataWriter.java
+++ b/cool-core/src/main/java/com/nus/cool/core/util/writer/NativeDataWriter.java
@@ -122,7 +122,9 @@ public class NativeDataWriter implements DataWriter {
     private void finishCublet() throws IOException {
         // write metaChunk begin from current offset.
         this.metaChunk.updateBeginOffset(this.offset);
+        this.metaChunk.complete();
         offset += this.metaChunk.writeTo(out);
+        this.metaChunk.cleanForNextCublet();
         // record header offset
         chunkHeaderOffsets.add(offset - Ints.BYTES);
         // 1. write number of chunks

--- a/cool-core/src/test/java/com/nus/cool/core/io/store/CubeMetaTest.java
+++ b/cool-core/src/test/java/com/nus/cool/core/io/store/CubeMetaTest.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +71,8 @@ public class CubeMetaTest {
     }
     this.parser = new CsvTupleParser();
 
-    this.metaws = MetaChunkWS.newMetaChunkWS(this.schema, 0);
+    this.metaws = MetaChunkWS.newMetaChunkWS(this.schema, 0,
+      schema.getUserKeyField(), new ArrayList<Integer>());
   }
 
   @AfterTest
@@ -79,9 +81,9 @@ public class CubeMetaTest {
   }
 
   @Test
-  public void CubeMetaUnbitTest() throws IOException {
+  public void CubeMetaUnitTest() throws IOException {
     while (reader.hasNext()) {
-      metaws.put(parser.parse(reader.next()));
+      metaws.put(parser.parse(reader.next()), this.schema.getInvariantType());
     }
     
     DataOutputBuffer out = new DataOutputBuffer();

--- a/cool-core/src/test/java/com/nus/cool/core/io/store/CubeMetaTest.java
+++ b/cool-core/src/test/java/com/nus/cool/core/io/store/CubeMetaTest.java
@@ -1,0 +1,104 @@
+package com.nus.cool.core.io.store;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Paths;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.nus.cool.core.io.DataOutputBuffer;
+import com.nus.cool.core.io.readstore.CubeMetaRS;
+import com.nus.cool.core.io.writestore.MetaChunkWS;
+import com.nus.cool.core.schema.FieldSchema;
+import com.nus.cool.core.schema.TableSchema;
+import com.nus.cool.core.util.parser.CsvTupleParser;
+import com.nus.cool.core.util.parser.TupleParser;
+import com.nus.cool.core.util.reader.LineTupleReader;
+import com.nus.cool.core.util.reader.TupleReader;
+
+public class CubeMetaTest {
+  static final Logger logger = LoggerFactory.getLogger(CubeMetaTest.class);
+  private TableSchema schema;
+  private TupleReader reader;
+  private TupleParser parser;
+  private MetaChunkWS metaws;
+
+  private String[] expected = {
+    "{\"charset\":\"UTF-8\",\"type\":\"UserKey\",\"values\":[\"P-0\",\"P-1\",\"P-10\",\"P-11\",\"P-12\",\"P-2\",\"P-3\",\"P-4\",\"P-5\",\"P-6\",\"P-7\",\"P-8\",\"P-9\"]}",
+    "{\"type\":\"Metric\",\"min\":1954,\"max\":2000}",
+    "{\"charset\":\"UTF-8\",\"type\":\"Action\",\"values\":[\"diagnose\",\"labtest\",\"prescribe\"]}",
+    "{\"charset\":\"UTF-8\",\"type\":\"Segment\",\"values\":[\"Disease-A\",\"Disease-B\",\"Disease-C\",\"None\"]}",
+    "{\"charset\":\"UTF-8\",\"type\":\"Segment\",\"values\":[\"Medicine-A\",\"Medicine-B\",\"Medicine-C\",\"None\"]}",
+    "{\"charset\":\"UTF-8\",\"type\":\"Segment\",\"values\":[\"Labtest-A\",\"Labtest-B\",\"Labtest-C\",\"None\"]}",
+    "{\"type\":\"Metric\",\"min\":0,\"max\":76}",
+    "{\"type\":\"ActionTime\",\"min\":15340,\"max\":15696}"
+  };
+
+  @BeforeTest
+  public void setup() {
+    logger.info("Start UnitTest " + CubeMetaTest.class.getSimpleName());
+    String sourcePath = Paths.get(System.getProperty("user.dir"),
+      "src",
+      "test",
+      "java",
+      "com",
+      "nus",
+      "cool",
+      "core",
+      "resources").toString();
+    String schemaPath = Paths.get(sourcePath, "health", "table.yaml").toString();
+    try {
+      this.schema = TableSchema.read(new File(schemaPath));
+    } catch (IOException e) {
+      System.err.println("cannot read test data schema file");
+      e.printStackTrace();
+    }
+    
+    String dataPath = Paths.get(sourcePath, "health", "table.csv").toString();
+    try {
+      this.reader = new LineTupleReader(new File(dataPath));
+    } catch (IOException e) {
+      System.err.println("cannot read test data csv file");
+      e.printStackTrace();
+    }
+    this.parser = new CsvTupleParser();
+
+    this.metaws = MetaChunkWS.newMetaChunkWS(this.schema, 0);
+  }
+
+  @AfterTest
+  public void tearDown() {
+    logger.info(String.format("Tear down UnitTest %s\n", CubeMetaTest.class.getSimpleName()));
+  }
+
+  @Test
+  public void CubeMetaUnbitTest() throws IOException {
+    while (reader.hasNext()) {
+      metaws.put(parser.parse(reader.next()));
+    }
+    
+    DataOutputBuffer out = new DataOutputBuffer();
+    metaws.complete();
+    int written = metaws.writeCubeMeta(out);
+    out.close();
+
+    ByteBuffer buffer = ByteBuffer.wrap(out.getData())
+      .order(ByteOrder.nativeOrder());
+    buffer.limit(written);
+
+    CubeMetaRS cubemeta = new CubeMetaRS(this.schema);
+    cubemeta.readFrom(buffer);
+    int idx = 0;
+    for (FieldSchema field : schema.getFields()) {
+      String fieldmeta = cubemeta.getFieldMeta(field.getName());
+      Assert.assertEquals(fieldmeta, expected[idx++]);
+    }
+  }
+}

--- a/cool-core/src/test/java/com/nus/cool/functionality/CsvLoaderTest.java
+++ b/cool-core/src/test/java/com/nus/cool/functionality/CsvLoaderTest.java
@@ -47,34 +47,19 @@ public class CsvLoaderTest {
 
     @DataProvider(name = "CsvLoaderTestDP")
     public Object[][] CsvLoaderTestDPArgObjects() {
-        String sourcePath = Paths.get(System.getProperty("user.dir"),
-                "src",
-                "test",
-                "java",
-                "com",
-                "nus",
-                "cool",
-                "core",
-                "resources").toString();
         return new Object[][] {
                 {
                     "health",
-                    // Paths.get(sourcePath, "health", "table.yaml").toString(),
-                    // Paths.get(sourcePath, "health", "table.csv").toString(),
                     Paths.get(System.getProperty("user.dir"),  "..", "datasets/health", "table.yaml").toString(),
                     Paths.get(System.getProperty("user.dir"),  "..", "datasets/health", "data.csv").toString(),
                     Paths.get(System.getProperty("user.dir"),  "..", "CubeRepo").toString()
                 }, {
                     "sogamo",
-                    // Paths.get(sourcePath, "sogamo", "table.yaml").toString(),
-                    // Paths.get(sourcePath, "sogamo", "table.csv").toString(),
                     Paths.get(System.getProperty("user.dir"),  "..", "datasets/sogamo", "table.yaml").toString(),
                     Paths.get(System.getProperty("user.dir"),  "..", "datasets/sogamo", "data.csv").toString(),
                     Paths.get(System.getProperty("user.dir"),  "..", "CubeRepo").toString()
                 }, {
                     "tpc-h-10g",
-                    // Paths.get(sourcePath, "olap-tpch", "table.yaml").toString(),
-                    // Paths.get(sourcePath, "olap-tpch", "table.csv").toString(),
                     Paths.get(System.getProperty("user.dir"),  "..", "datasets/olap-tpch", "table.yaml").toString(),
                     Paths.get(System.getProperty("user.dir"),  "..", "datasets/olap-tpch", "scripts", "data.csv").toString(),
                     Paths.get(System.getProperty("user.dir"),  "..", "CubeRepo").toString()


### PR DESCRIPTION
This PR aims to address Issue #67 .

The overall plan is to add a cubemeta file that describes the value ranges of each field of a cube. The metachunk of each cublet will only have relevant information of its cublet. (This also implies that the same string value of the same field can have different id in different cublet. Similar to the local id in datachunk to improve compression. Now we have the cublet local id).

MetaChunkWS and MetaFieldWS now keeps the field meta info across a load process to generate the cubemeta field in the end.

A new CubeMetaRS is added to read the written out cubemet and describe each field in a json string.