### PR TITLE
Fix: xor to long conversion bug in float compression/decompression

### DIFF
--- a/cool-core/src/main/java/com/nus/cool/core/io/compression/FloatCompressor.java
+++ b/cool-core/src/main/java/com/nus/cool/core/io/compression/FloatCompressor.java
@@ -42,7 +42,7 @@ public class FloatCompressor implements Compressor {
     }
     // get the xor value
     int xor = Float.floatToIntBits(f) ^ Float.floatToIntBits(ctx.lastVal);
-    BitSet xorBits = BitSet.valueOf(new long[]{xor});
+    BitSet xorBits = BitSet.valueOf(new long[]{Integer.toUnsignedLong(xor)});
     // get the diff range
     int diffFirst = xorBits.nextSetBit(0);
     int diffLast = xorBits.previousSetBit(xorBits.size());

--- a/cool-core/src/main/java/com/nus/cool/core/io/storevector/FloatInputVector.java
+++ b/cool-core/src/main/java/com/nus/cool/core/io/storevector/FloatInputVector.java
@@ -45,7 +45,7 @@ public class FloatInputVector implements InputVector<Float> {
         for (int j = 0; j < lastDiffSize; j++) {
           xor.set(lastDiffStart + j, bs.get(startoff + 2 + j));
         }
-        xor.xor(BitSet.valueOf(new long[]{Float.floatToIntBits(lastVal)}));
+        xor.xor(BitSet.valueOf(new long[]{Integer.toUnsignedLong(Float.floatToIntBits(lastVal))}));
         float targetVal = Float.intBitsToFloat(xor.isEmpty() ? 0 : (int) xor.toLongArray()[0]);
         lastVal = targetVal;
         data[i] = lastVal;
@@ -67,7 +67,7 @@ public class FloatInputVector implements InputVector<Float> {
         for (int j = 0; j < lastDiffSize; j++) {
           xor.set(lastDiffStart + j, bs.get(startoff + 2 + 5 + 6 + j));
         }
-        xor.xor(BitSet.valueOf(new long[]{Float.floatToIntBits(lastVal)}));
+        xor.xor(BitSet.valueOf(new long[]{Integer.toUnsignedLong(Float.floatToIntBits(lastVal))}));
         float targetVal = Float.intBitsToFloat(xor.isEmpty() ? 0 : (int) xor.toLongArray()[0]);
         lastVal = targetVal;
         data[i] = lastVal;

--- a/cool-core/src/test/java/com/nus/cool/core/io/storevector/FloatInputVectorTest.java
+++ b/cool-core/src/test/java/com/nus/cool/core/io/storevector/FloatInputVectorTest.java
@@ -66,6 +66,8 @@ public class FloatInputVectorTest {
         { new Float[] { 15.5f, 135296f, 132096f, 136320f, 132352f}}, // test case 2
         { new Float[] { 10.3f, 1.2f, 1.2f, 1.2f, 1.2f, 1.2f, 1.2f, 1.2f, 1.2f,
             1.2f}}, // test case 1 with many equal values
+        { new Float[] { -1.0f, -1.0f, -1.0f, -1.0f, 29.60f, 6.70f,
+            60.5f}}, // test case with xor 32 bit value
     };
   }
 }


### PR DESCRIPTION
This fix issue #130 as per the solution described there. A new test case is added in `FloatInputVectorTest,java` to test it.