### PR TITLE
136 restructure cohort result output

### DIFF
--- a/cool-core/src/main/java/com/nus/cool/core/cohort/CohortProcessor.java
+++ b/cool-core/src/main/java/com/nus/cool/core/cohort/CohortProcessor.java
@@ -120,13 +120,14 @@ public class CohortProcessor {
   }
 
   /**
-   * Read all cohorts from the results of a previous query,
+   * Read one cohort from the results of a previous query,
    * cohort is named cohortName.cohort, e,g. "1980-1990.cohort".
    * Where 1980-1990 is the cohortName in our cohort query for health-raw dataset.
    *
+   * @param cohortName name of the previous stored cohort.
    * @param cohortFolderPath the path to store the previous stored cohort.
    */
-  public void readQueryCohort(String cohortName, String cohortFolderPath) throws IOException {
+  public void readOneCohort(String cohortName, String cohortFolderPath) throws IOException {
     
     // check folder
     File folder = new File(cohortFolderPath);
@@ -135,10 +136,7 @@ public class CohortProcessor {
       return;
     }
     File cohortFile = new File(folder, cohortName + ".cohort");
-
-    CohortRSStr crs = new CohortRSStr(StandardCharsets.UTF_8);
-    crs.readFrom(Files.map(cohortFile));
-    this.previousCohortUsers.addAll(crs.getUsers());
+    readOneCohort(cohortFile);
   }
 
   /**

--- a/cool-core/src/main/java/com/nus/cool/core/cohort/CohortProcessor.java
+++ b/cool-core/src/main/java/com/nus/cool/core/cohort/CohortProcessor.java
@@ -25,7 +25,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
-
 import lombok.Getter;
 
 /**
@@ -127,25 +126,19 @@ public class CohortProcessor {
    *
    * @param cohortFolderPath the path to store the previous stored cohort.
    */
-  public void readQueryCohorts(String cohortFolderPath) throws IOException {
-    CohortRSStr crs = new CohortRSStr(StandardCharsets.UTF_8);
-
-    File file = new File(cohortFolderPath);
-    File[] fs = file.listFiles();
+  public void readQueryCohort(String cohortName, String cohortFolderPath) throws IOException {
+    
+    // check folder
+    File folder = new File(cohortFolderPath);
+    File[] fs = folder.listFiles();
     if (fs == null) {
       return;
     }
-    for (File f : fs) {
-      int pointIndex = f.getName().lastIndexOf(".");
-      if (pointIndex == -1) {
-        continue;
-      }
-      String extension = f.getName().substring(pointIndex);
-      if (!f.isDirectory() && extension.equals(".cohort")) {
-        crs.readFrom(Files.map(f));
-        this.previousCohortUsers.addAll(crs.getUsers());
-      }
-    }
+    File cohortFile = new File(folder, cohortName + ".cohort");
+
+    CohortRSStr crs = new CohortRSStr(StandardCharsets.UTF_8);
+    crs.readFrom(Files.map(cohortFile));
+    this.previousCohortUsers.addAll(crs.getUsers());
   }
 
   /**

--- a/cool-core/src/main/java/com/nus/cool/core/cohort/CohortQueryLayout.java
+++ b/cool-core/src/main/java/com/nus/cool/core/cohort/CohortQueryLayout.java
@@ -39,6 +39,12 @@ public class CohortQueryLayout {
   @JsonProperty("inputCohort")
   private String inputCohort;
 
+  @JsonProperty("outputCohort")
+  private String outputCohort;
+
+  @JsonProperty("outputAll")
+  private boolean outputAll;
+
   /**
    * Read the cohort query in a json.
    */

--- a/cool-core/src/main/java/com/nus/cool/core/cohort/CohortQueryLayout.java
+++ b/cool-core/src/main/java/com/nus/cool/core/cohort/CohortQueryLayout.java
@@ -58,6 +58,10 @@ public class CohortQueryLayout {
     return readFromJson(new File(path));
   }
 
+  public boolean selectAll() {
+    return this.cohortSelectionLayout.getType() == FilterType.ALL;
+  }
+
   /**
    * Return the schema set.
    */

--- a/cool-core/src/main/java/com/nus/cool/core/cohort/CohortResultLayout.java
+++ b/cool-core/src/main/java/com/nus/cool/core/cohort/CohortResultLayout.java
@@ -16,26 +16,22 @@ public class CohortResultLayout {
   @AllArgsConstructor
   @JsonSerializableSchema
   private static class CohortResInfo {
-    @JsonProperty("name")
-    private String name;
     @JsonProperty("cohortName")
     private String cohortName;
     @JsonProperty("cohortSize")
     private int cohortSize;
   }
 
-  private CohortQueryLayout cohortQuery;
   private ArrayList<CohortResInfo> cohortResList = new ArrayList<>();
 
   /**
    * Adding a cohort res.
    *
-   * @param name cohort file name
    * @param cohortName cohortName
    * @param cohortSize cohortSize
    */
-  public void addOneCohortRes(String name, String cohortName, int cohortSize) {
-    CohortResInfo cRes = new CohortResInfo(name, cohortName, cohortSize);
+  public void addOneCohortRes(String cohortName, int cohortSize) {
+    CohortResInfo cRes = new CohortResInfo(cohortName, cohortSize);
     this.cohortResList.add(cRes);
   }
 }

--- a/cool-core/src/main/java/com/nus/cool/core/cohort/CohortWriter.java
+++ b/cool-core/src/main/java/com/nus/cool/core/cohort/CohortWriter.java
@@ -1,0 +1,81 @@
+package com.nus.cool.core.cohort;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import com.nus.cool.core.cohort.storage.CohortRet;
+import com.nus.cool.core.cohort.storage.CohortWSStr;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Set;
+
+/**
+ * a collection of methods to persist cohort processing result (CohortRet).
+ */
+public interface CohortWriter {
+
+  /**
+   * setup the directory to be used by other CohortWriter utilities.
+   * a recommended path format: cube-repo/cohort/queryName.
+   */
+  public static boolean setUpOutputFolder(String outputPath) {
+    return new File(outputPath).mkdirs();
+  }
+  
+  /**
+   * Persist cohort file .cohort to output disk to the same level with the .dz file.
+   * E,g. ../CubeRepo/health_raw/v00000012/cohort/queryName/all.cohort.
+   *
+   * @param outputDir the output file path
+   * @throws IOException IOException
+   */
+  public static void persistCohortResult(CohortRet res, String outputDir) throws IOException {
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      String cohortJson = Paths.get(outputDir, "query_res.json").toString();
+      mapper.writeValue(new File(cohortJson), res.genResult());
+    } catch (JsonGenerationException e) {
+      System.out.println("failed to generate json for result: " + e);
+    } catch (JsonMappingException e) {
+      System.out.println("failed to generate json for result: " + e);
+    }
+  }
+
+  /**
+   * Output the users of a cohort to file.
+   *
+   * @param res cohort processing result
+   * @param cohortName the cohort to output
+   * @param outputDir the directory to store the file
+   */
+  public static void persistOneCohort(CohortRet res, String cohortName, String outputDir) {
+    try {
+      Optional<CohortWSStr> cohort = res.genCohortUser(cohortName);
+      if (!cohort.isPresent()) {
+        System.out.println("failed to persist cohort: " + cohortName + " " + "(not found)");
+        return;
+      }
+      String fileName = cohortName + ".cohort";
+      File cohortResFile = new File(outputDir, fileName);      
+      DataOutputStream out = new DataOutputStream(new FileOutputStream(cohortResFile));
+      cohort.get().writeTo(out);
+      out.close();
+    } catch (IOException e) {
+      System.out.println("failed to persist cohort: " + cohortName + " " + e);
+    }
+  }
+
+  /**
+   * Persist a set of cohorts from the result in to individual files.
+   *
+   * @param picked named cohorts to write out.
+   */
+  public static void persistSelectedCohorts(CohortRet res, Set<String> picked, String outputDir)
+      throws IOException {
+    picked.stream().forEach(x -> persistOneCohort(res, x, outputDir));
+  }
+}

--- a/cool-core/src/main/java/com/nus/cool/core/cohort/CohortWriter.java
+++ b/cool-core/src/main/java/com/nus/cool/core/cohort/CohortWriter.java
@@ -46,15 +46,11 @@ public interface CohortWriter {
   }
 
   /**
-   * Output the users of a cohort to file.
-   *
-   * @param res cohort processing result
-   * @param cohortName the cohort to output
-   * @param outputDir the directory to store the file
+   * Persist the cohort write store into a file.
    */
-  public static void persistOneCohort(CohortRet res, String cohortName, String outputDir) {
+  public static void persistCohortWS(String cohortName, Optional<CohortWSStr> cohort,
+      String outputDir) {
     try {
-      Optional<CohortWSStr> cohort = res.genCohortUser(cohortName);
       if (!cohort.isPresent()) {
         System.out.println("failed to persist cohort: " + cohortName + " " + "(not found)");
         return;
@@ -70,12 +66,33 @@ public interface CohortWriter {
   }
 
   /**
-   * Persist a set of cohorts from the result in to individual files.
+   * Output the users of a cohort to file.
+   *
+   * @param res cohort processing result
+   * @param cohortName the cohort to output
+   * @param outputDir the directory to store the file
+   */
+  public static void persistOneCohort(CohortRet res, String cohortName, String outputDir) {
+    Optional<CohortWSStr> cohort = res.genCohortUser(cohortName);
+    persistCohortWS(cohortName, cohort, outputDir);
+  }
+
+  /**
+   * Persist a set of cohorts from the result into individual files.
    *
    * @param picked named cohorts to write out.
    */
-  public static void persistSelectedCohorts(CohortRet res, Set<String> picked, String outputDir)
-      throws IOException {
+  public static void persistSelectedCohorts(CohortRet res, Set<String> picked, String outputDir) {
     picked.stream().forEach(x -> persistOneCohort(res, x, outputDir));
+  }
+
+  /**
+   * Persist all non-empty cohorts from the result into individual files.
+   */
+  public static void persistAllCohorts(CohortRet res, String outputDir) {
+    res.genAllCohortUsers()
+        .entrySet()
+        .stream()
+        .forEach(x -> persistCohortWS(x.getKey(), x.getValue(), outputDir));
   }
 }

--- a/cool-core/src/main/java/com/nus/cool/core/cohort/storage/CohortRSStr.java
+++ b/cool-core/src/main/java/com/nus/cool/core/cohort/storage/CohortRSStr.java
@@ -64,12 +64,17 @@ public class CohortRSStr implements Input {
 
   @Override
   public void readFrom(ByteBuffer buffer) {
-    InputVector<String> valueVec = InputVectorFactory.genStrFieldInputVector(buffer, this.charset);
-    int valueCount = valueVec.size();
-    values = new ArrayList<>(valueCount);
-    for (int i = 0; i < valueCount; i++) {
-      String value = valueVec.get(i);
-      values.add(value);
+    try {
+      InputVector<String> valueVec =
+          InputVectorFactory.genStrFieldInputVector(buffer, this.charset);
+      int valueCount = valueVec.size();
+      values = new ArrayList<>(valueCount);
+      for (int i = 0; i < valueCount; i++) {
+        String value = valueVec.get(i);
+        values.add(value);
+      }
+    } catch (IllegalArgumentException e) {
+      System.out.println("invalid argument for cohort user loading");
     }
   }
 

--- a/cool-core/src/main/java/com/nus/cool/core/cohort/storage/CohortRet.java
+++ b/cool-core/src/main/java/com/nus/cool/core/cohort/storage/CohortRet.java
@@ -1,13 +1,18 @@
 package com.nus.cool.core.cohort.storage;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.nus.cool.core.cohort.CohortResultLayout;
 import com.nus.cool.core.cohort.ageselect.AgeSelectionLayout;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
-import lombok.Getter;
+import java.util.Set;
 
 /**
  * Class for Cohort Analysis Result We consider the Cohort Analysis Result as a
@@ -28,8 +33,22 @@ public class CohortRet {
 
   private int size;
 
-  @Getter
-  private final HashMap<String, List<String>> cohortToUserIdList = new HashMap<>();
+  private class UserList {
+    Set<String> added = new HashSet<>();
+    List<String> userSequence = new LinkedList<>();
+
+    int size() {
+      return userSequence.size();
+    }
+
+    void add(String user) {
+      if (!added.contains(user)) {
+        userSequence.add(user);
+      }
+    }
+  }
+
+  private final Map<String, UserList> cohortToUserIdList = new HashMap<>();
 
   /**
    * Create a cohort ret with ageSelection.
@@ -133,8 +152,7 @@ public class CohortRet {
    */
   public void addUserid(String cohortName, String userId) {
     if (!this.cohortToUserIdList.containsKey(cohortName)) {
-      List<String> userIdList = new ArrayList<>();
-      this.cohortToUserIdList.put(cohortName, userIdList);
+      this.cohortToUserIdList.put(cohortName, new UserList());
     }
     this.cohortToUserIdList.get(cohortName).add(userId);
   }
@@ -159,6 +177,27 @@ public class CohortRet {
     }
     Xaxis x = this.cohortToValueList.get(cohort);
     return x.getValues();
+  }
+
+  public CohortResultLayout genResult() {
+    CohortResultLayout ret = new CohortResultLayout();
+    for (Map.Entry<String, UserList> e : this.cohortToUserIdList.entrySet()) {
+      ret.addOneCohortRes(e.getKey(), e.getValue().size());
+    }
+    return ret;
+  }
+
+  public Optional<CohortWSStr> genCohortUser(String cohortName) {
+    return Optional.of(this.cohortToUserIdList.get(cohortName))
+      .transform(x -> {
+        if (x.size()==0) {
+          return null;
+        } else {
+          CohortWSStr c = new CohortWSStr();
+          c.addCubletResults(x.userSequence);
+          return c;
+        }
+      }); 
   }
 
   @Override

--- a/cool-core/src/main/java/com/nus/cool/core/cohort/storage/ProjectedTuple.java
+++ b/cool-core/src/main/java/com/nus/cool/core/cohort/storage/ProjectedTuple.java
@@ -2,8 +2,9 @@ package com.nus.cool.core.cohort.storage;
 
 import com.nus.cool.core.field.FieldValue;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 /**
  * Partial of a tuple in project, when generated, the layout of schemas is
@@ -14,7 +15,7 @@ public class ProjectedTuple {
 
   private FieldValue[] tuple;
 
-  private HashMap<String, Integer> schema2Index;
+  private Map<String, Integer> schema2Index;
 
   /**
    * Get the value by field name.
@@ -29,7 +30,7 @@ public class ProjectedTuple {
   /**
    * Create a partial tuple with selected fields.
    */
-  public ProjectedTuple(HashSet<String> schemaList) {
+  public ProjectedTuple(Set<String> schemaList) {
     this.schema2Index = new HashMap<>();
     int idx = 0;
     for (String schema : schemaList) {

--- a/cool-core/src/main/java/com/nus/cool/functionality/CohortAnalysis.java
+++ b/cool-core/src/main/java/com/nus/cool/functionality/CohortAnalysis.java
@@ -20,8 +20,10 @@
 
 package com.nus.cool.functionality;
 
+import com.google.common.io.Files;
 import com.nus.cool.core.cohort.CohortProcessor;
 import com.nus.cool.core.cohort.CohortQueryLayout;
+import com.nus.cool.core.cohort.CohortWriter;
 import com.nus.cool.core.cohort.storage.CohortRet;
 import com.nus.cool.core.io.readstore.CubeRS;
 import com.nus.cool.model.CoolModel;
@@ -58,12 +60,15 @@ public class CohortAnalysis {
       }
     }
 
-    // get current dir path
+    // run analysis
     CohortRet ret = cohortProcessor.process(cube);
-    String cohortStoragePath = cohortProcessor.persistCohort(currentVersion.toString());
-    cohortProcessor.readQueryCohorts(cohortStoragePath);
-    coolModel.close();
 
+    // persist the results
+    String outputPath = currentVersion.toString() + "/cohort/" + layout.getQueryName();
+    CohortWriter.setUpOutputFolder(outputPath);
+    Files.copy(new File(queryPath), new File(outputPath + "/query.json"));;
+    CohortWriter.persistCohortResult(ret, outputPath);
+    coolModel.close();
     return ret;
   }
 

--- a/cool-core/src/main/java/com/nus/cool/functionality/CohortSelection.java
+++ b/cool-core/src/main/java/com/nus/cool/functionality/CohortSelection.java
@@ -62,8 +62,14 @@ public class CohortSelection {
     // persist cohort
     if (layout.selectAll()) {
       CohortWriter.persistOneCohort(ret, "all", outputPath); 
+    } else if (layout.isOutputAll()) {
+      CohortWriter.persistAllCohorts(ret, outputPath); 
+    } else {
+      String outputCohort = layout.getOutputCohort();
+      if (outputCohort != null && !outputCohort.isEmpty()) {
+        CohortWriter.persistOneCohort(ret, outputCohort, outputPath);
+      }
     }
-    // TODO should handle explicit picked cohort.
 
     coolModel.close();
 

--- a/cool-core/src/test/java/com/nus/cool/core/ProcessorTest.java
+++ b/cool-core/src/test/java/com/nus/cool/core/ProcessorTest.java
@@ -65,14 +65,6 @@ public class ProcessorTest extends CsvLoaderTest {
     CubeRS cube = coolModel.getCube(cohortProcessor.getDataSource());
     File currentVersion = this.coolModel.getCubeStorePath(cohortProcessor.getDataSource());
 
-    // load input cohort
-    if (cohortProcessor.getInputCohort() != null) {
-      File cohortFile = new File(currentVersion, "cohort/" + cohortProcessor.getInputCohort());
-      if (cohortFile.exists()) {
-        cohortProcessor.readOneCohort(cohortFile);
-      }
-    }
-
     // get current dir path
     CohortRet ret = cohortProcessor.process(cube);
 
@@ -93,7 +85,7 @@ public class ProcessorTest extends CsvLoaderTest {
     }
 
     // check loading cohort
-    cohortProcessor.readQueryCohort(layout.getOutputCohort(), outputPath);
+    cohortProcessor.readOneCohort(layout.getOutputCohort(), outputPath);
     Assert.assertTrue(cohortProcessor.getInputCohortSize() > 0);
   }
 

--- a/cool-core/src/test/java/com/nus/cool/core/ProcessorTest.java
+++ b/cool-core/src/test/java/com/nus/cool/core/ProcessorTest.java
@@ -83,12 +83,18 @@ public class ProcessorTest extends CsvLoaderTest {
     CohortWriter.persistCohortResult(ret, outputPath);
     if (layout.selectAll()) {
       CohortWriter.persistOneCohort(ret, "all", outputPath); 
+    } else if (layout.isOutputAll()) {
+      CohortWriter.persistAllCohorts(ret, outputPath); 
+    } else {
+      String outputCohort = layout.getOutputCohort();
+      if (outputCohort != null && !outputCohort.isEmpty()) {
+        CohortWriter.persistOneCohort(ret, outputCohort, outputPath);
+      }
     }
 
-    // // check loading cohort
-    // // TODO: write a separate unit test
-    // cohortProcessor.readQueryCohorts(outputPath);
-    // Assert.assertTrue(cohortProcessor.getInputCohortSize() > 0);
+    // check loading cohort
+    cohortProcessor.readQueryCohort(layout.getOutputCohort(), outputPath);
+    Assert.assertTrue(cohortProcessor.getInputCohortSize() > 0);
   }
 
   /**

--- a/cool-queryserver/src/main/java/com/nus/cool/queryserver/handler/CohortController.java
+++ b/cool-queryserver/src/main/java/com/nus/cool/queryserver/handler/CohortController.java
@@ -3,11 +3,15 @@ package com.nus.cool.queryserver.handler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nus.cool.core.cohort.CohortProcessor;
 import com.nus.cool.core.cohort.CohortQueryLayout;
+import com.nus.cool.core.cohort.CohortWriter;
+import com.nus.cool.core.cohort.storage.CohortRet;
 import com.nus.cool.core.io.readstore.CubeRS;
 import com.nus.cool.model.CoolModel;
 import com.nus.cool.queryserver.singleton.ModelConfig;
 import com.nus.cool.queryserver.utils.Util;
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import javax.ws.rs.QueryParam;
 import org.springframework.http.MediaType;
@@ -94,11 +98,25 @@ public class CohortController {
     System.out.println("reload success...");
     CohortProcessor cohortProcessor = new CohortProcessor(layout);
     CubeRS cubeRS = ModelConfig.cachedCoolModel.getCube(cohortProcessor.getDataSource());
-    String res = cohortProcessor.process(cubeRS).toString();
+    CohortRet ret = cohortProcessor.process(cubeRS);
     File currentVersion =
         ModelConfig.cachedCoolModel.getLatestVersion(cohortProcessor.getDataSource());
-    cohortProcessor.persistCohort(currentVersion.toString());
-    return ResponseEntity.ok().body(res);
+    // store the cohort
+    String outputPath = currentVersion.toString() + "/cohort/" + layout.getQueryName();
+    CohortWriter.setUpOutputFolder(outputPath);
+    // store the query
+    BufferedWriter writer = new BufferedWriter(new FileWriter(outputPath + "/query.json"));
+    writer.write(queryContent);
+    writer.close();
+    // store results
+    CohortWriter.persistCohortResult(ret, outputPath);
+    // persist cohort
+    if (layout.selectAll()) {
+      CohortWriter.persistOneCohort(ret, "all", outputPath); 
+    }
+    // TODO need to consider ouput picked cohort.
+
+    return ResponseEntity.ok().body(ret.toString());
   }
 
   /**

--- a/cool-queryserver/src/main/java/com/nus/cool/queryserver/handler/CohortController.java
+++ b/cool-queryserver/src/main/java/com/nus/cool/queryserver/handler/CohortController.java
@@ -113,8 +113,14 @@ public class CohortController {
     // persist cohort
     if (layout.selectAll()) {
       CohortWriter.persistOneCohort(ret, "all", outputPath); 
+    } else if (layout.isOutputAll()) {
+      CohortWriter.persistAllCohorts(ret, outputPath); 
+    } else {
+      String outputCohort = layout.getOutputCohort();
+      if (outputCohort != null && !outputCohort.isEmpty()) {
+        CohortWriter.persistOneCohort(ret, outputCohort, outputPath);
+      }
     }
-    // TODO need to consider ouput picked cohort.
 
     return ResponseEntity.ok().body(ret.toString());
   }

--- a/datasets/health_raw/sample_query_distinctcount/query.json
+++ b/datasets/health_raw/sample_query_distinctcount/query.json
@@ -46,5 +46,6 @@
         "function":"DISTINCT",
         "observedSchema":"id"
     },
-    "dataSource": "health_raw"
+    "dataSource": "health_raw", 
+    "outputCohort": "1950-1960"
 }

--- a/datasets/health_raw/sample_query_selection/query.json
+++ b/datasets/health_raw/sample_query_selection/query.json
@@ -14,6 +14,5 @@
             }
         ]
     },
-
     "dataSource": "health_raw"
 }


### PR DESCRIPTION
# Changes

* cohort result is written out to a folder named by the query. There was a result file and cohort files, and the result file contains the query and the result.
* query is separated from the result and stored under the same folder.
* flexibility in choosing what to write out: there are static methods defined under the `CohortWriter` interface that can be used to write out cohort/query/result.
* For cohort selection the old logic works that it has an empty cohortselector so the output cohort will have the name "all.cohort".
* With non-empty cohortselector, now user can use the two additional fields `outputCohort` and `outputAll` to pick one cohort user list to write out or all.