### PR TITLE
Parsing of ActionTime from both day and second resolution format

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,28 +100,26 @@ We provide an example for cohort query processing in [CohortAnalysis.java](cool-
 
 ## Example: Cohort Analysis
 
-### Load dataset
+### Load dataset from different formats
 
 We have provided examples in `sogamo` directory and `health_raw` directory. Now we take `sogamo` for example.
 
 The COOL system supports CSV data format by default, and you can load `sogamo` dataset with the following command.
 
 ```bash
-./cool load \
+./cool load csv \
     sogamo \
     datasets/sogamo/table.yaml \
     datasets/sogamo/data.csv \
     ./CubeRepo
 ```
 
-<!-- disabled as currently not working -->
-<!--
 In addition, you can run the following command to load the dataset in other formats under the `sogamo` directory.
 
 - parquet format data
 
 ```bash
-java -jar cool-extensions/parquet-extensions/target/parquet-extensions-0.1-SNAPSHOT.jar \
+./cool load parquet \
     sogamo \
     datasets/sogamo/table.yaml \
     datasets/sogamo/data.parquet \
@@ -131,7 +129,7 @@ java -jar cool-extensions/parquet-extensions/target/parquet-extensions-0.1-SNAPS
 - Arrow format data
 
 ```bash
-java -jar cool-extensions/arrow-extensions/target/arrow-extensions-0.1-SNAPSHOT.jar \
+./cool load arrow \
     sogamo \
     datasets/sogamo/table.yaml \
     datasets/sogamo/data.arrow \
@@ -141,14 +139,13 @@ java -jar cool-extensions/arrow-extensions/target/arrow-extensions-0.1-SNAPSHOT.
 - Avro format data
 
 ```bash
-java -jar cool-extensions/avro-extensions/target/avro-extensions-0.1-SNAPSHOT.jar \
+./cool load avro \
     sogamo \
     datasets/sogamo/table.yaml \
     datasets/sogamo/avro/test.avro \
     ./CubeRepo \
     datasets/sogamo/avro/schema.avsc
 ```
--->
 
 There will be a cube generated under the `./CubeRepo` directory, which is named `sogamo`.
 
@@ -162,7 +159,7 @@ Similarly, load the `health_raw` dataset with:
     ./CubeRepo
 ```
 
-### Execute queries
+### Execute cohort queries
 
 We use the `health_raw` dataset for example to demonstrate the cohort analysis.
 
@@ -211,7 +208,7 @@ We use the `sogamo` dataset for example to demonstrate the funnel analysis.
 
 ## Example: OLAP Analysis
 
-### Load dataset
+### Load OLAP dataset
 
 We have provided examples in `olap-tpch` directory.
 
@@ -227,7 +224,7 @@ The COOL system supports CSV data format by default, and you can load `tpc-h` da
 
 Finally, there will be a cube generated under the `./CubeRepo` directory, which is named `tpc-h-10g`.
 
-### Execute queries
+### Execute OLAP queries
 
 Run Server
 

--- a/cool
+++ b/cool
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 COOL_CORE_PATH="${COOL_CORE_JAR_PATH:-./cool-core/target/cool-core-0.1-SNAPSHOT.jar}"
+COOL_EXTENSION_PATH_PREFIX="${COOL_EXTENSION_PATH_PREFIX:-./cool-extensions}"
 COOL_QUERY_SERVER_PATH="${COOL_QUERY_SERVER_PATH:-./cool-queryserver/target/cool-queryserver-0.1-SNAPSHOT.jar}"
 
 
@@ -22,7 +23,25 @@ main_help() {
 }
 
 main_load() {
-    java -cp $COOL_CORE_PATH com.nus.cool.functionality.CsvLoader "$@"
+    case ${1} in csv)
+        java -cp $COOL_CORE_PATH com.nus.cool.functionality.CsvLoader "${@:2}"
+        ;;
+    parquet)
+        echo "java -jar $COOL_EXTENSION_PATH_PREFIX/parquet-extensions/target/parquet-extensions-0.1-SNAPSHOT.jar ${@:2}"
+        java -jar $COOL_EXTENSION_PATH_PREFIX/parquet-extensions/target/parquet-extensions-0.1-SNAPSHOT.jar "${@:2}"
+        ;;
+    avro)
+        java -jar $COOL_EXTENSION_PATH_PREFIX/avro-extensions/target/avro-extensions-0.1-SNAPSHOT.jar "${@:2}"
+        ;;
+    arrow)
+        java -jar $COOL_EXTENSION_PATH_PREFIX/arrow-extensions/target/arrow-extensions-0.1-SNAPSHOT.jar "${@:2}"
+        ;;
+    *)
+        echo "unknown format: $1"
+        main_help 1
+        exit 1
+        ;;
+    esac
 }
 
 main_cohortselection() {

--- a/cool-core/src/main/java/com/nus/cool/core/util/converter/SecondIntConverter.java
+++ b/cool-core/src/main/java/com/nus/cool/core/util/converter/SecondIntConverter.java
@@ -24,6 +24,8 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.Seconds;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.DateTimeFormatterBuilder;
+import org.joda.time.format.DateTimeParser;
 
 /**
  * SecondIntConverter converts the input day represented in format yyyy-MM-dd to integer
@@ -35,7 +37,14 @@ public class SecondIntConverter implements ActionTimeIntConverter {
    * Date formatter.
    */
   public static final DateTimeFormatter FORMATTER
-      = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").withZoneUTC();
+      = new DateTimeFormatterBuilder()
+      .append(
+        DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").getPrinter(),
+        new DateTimeParser[] {
+          DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").getParser(),
+          DateTimeFormat.forPattern("yyyy-MM-dd").getParser()
+        }
+      ).toFormatter().withZoneUTC();
 
   /**
    * Reference day.


### PR DESCRIPTION
This PR fixes #152 . The issue was due to `sogamo` data prepared in other formats used the old `ActionTime` format of `yyyy-MM-dd`. But the latest `ActionIntConverter` now only accepts `yyyy-MM-dd HH:mm:ss`. 

The fix extend the `ActionIntConverter` default impl to accept both formats and parse them to seconds since epoch. 